### PR TITLE
Improve map and slider performance

### DIFF
--- a/gui/chart_view/chart_view.py
+++ b/gui/chart_view/chart_view.py
@@ -53,7 +53,10 @@ class ChartView(QWidget):
         self.slider_start.setValue(0)
         self.slider_start.setTickInterval(1)
         self.slider_start.setTickPosition(QSlider.TicksBelow)
+        # Aktualizujemy etykietę na bieżąco, a wykres
+        # odświeżamy dopiero po puszczeniu suwaka.
         self.slider_start.valueChanged.connect(self.on_start_changed)
+        self.slider_start.sliderReleased.connect(self.redraw_chart)
 
         # Suwak końcowego roku
         self.label_end = QLabel(f"Do roku: {self.end_year}")
@@ -64,6 +67,7 @@ class ChartView(QWidget):
         self.slider_end.setTickInterval(1)
         self.slider_end.setTickPosition(QSlider.TicksBelow)
         self.slider_end.valueChanged.connect(self.on_end_changed)
+        self.slider_end.sliderReleased.connect(self.redraw_chart)
 
         sliders_layout.addWidget(self.label_start)
         sliders_layout.addWidget(self.slider_start)
@@ -104,7 +108,6 @@ class ChartView(QWidget):
             return
         self.start_year = year
         self.label_start.setText(f"Od roku: {self.start_year}")
-        self.redraw_chart()
 
     def on_end_changed(self, index: int):
         """
@@ -117,7 +120,6 @@ class ChartView(QWidget):
             return
         self.end_year = year
         self.label_end.setText(f"Do roku: {self.end_year}")
-        self.redraw_chart()
 
     def update_countries(self, countries: list):
         """

--- a/gui/map_view/electric_vehicles_map_tab.py
+++ b/gui/map_view/electric_vehicles_map_tab.py
@@ -6,7 +6,6 @@ import geopandas as gpd
 import plotly.graph_objects as go
 import plotly.io as pio
 import json
-import tempfile
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
 
@@ -22,8 +21,13 @@ class ElectricVehiclesMapTab(QWidget):
         self.start_year = self.years[0]
         self.end_year = self.years[-1]
 
-        # 2) Wczytujemy geometrię regionów (NUTS2)
+        # 2) Wczytujemy geometrię regionów (NUTS2) i filtrujemy tylko te,
+        #    dla których posiadamy dane. Na tym etapie zamieniamy je na
+        #    geojson, aby unikać kosztownej konwersji przy każdym
+        #    odświeżeniu mapy.
         self.map_data = self.load_map_data()
+        self.map_data = self.map_data[self.map_data["geo"].isin(self.ev_data["geo"].unique())]
+        self.map_geojson = json.loads(self.map_data.to_json())
 
         # ------------------------
         # Przygotowanie interfejsu Qt
@@ -40,7 +44,11 @@ class ElectricVehiclesMapTab(QWidget):
         self.slider_start.setValue(0)
         self.slider_start.setTickInterval(1)
         self.slider_start.setTickPosition(QSlider.TicksBelow)
+        # Aktualizujemy etykietę przy każdej zmianie, ale mapę
+        # odświeżamy dopiero po puszczeniu suwaka, aby ograniczyć
+        # liczbę ciężkich operacji renderowania.
         self.slider_start.valueChanged.connect(self.on_start_changed)
+        self.slider_start.sliderReleased.connect(self.render_map)
 
         self.label_end = QLabel(f"Do roku: {self.end_year}")
         self.slider_end = QSlider(Qt.Horizontal)
@@ -50,6 +58,7 @@ class ElectricVehiclesMapTab(QWidget):
         self.slider_end.setTickInterval(1)
         self.slider_end.setTickPosition(QSlider.TicksBelow)
         self.slider_end.valueChanged.connect(self.on_end_changed)
+        self.slider_end.sliderReleased.connect(self.render_map)
 
         sliders_layout.addWidget(self.label_start)
         sliders_layout.addWidget(self.slider_start)
@@ -62,6 +71,7 @@ class ElectricVehiclesMapTab(QWidget):
         self.web_view.setMinimumSize(1200, 800)
         self.layout.addWidget(self.web_view)
 
+        # Początkowe narysowanie mapy
         self.render_map()
 
     def on_start_changed(self, index: int):
@@ -71,7 +81,6 @@ class ElectricVehiclesMapTab(QWidget):
             return
         self.start_year = year
         self.label_start.setText(f"Od roku: {self.start_year}")
-        self.render_map()
 
     def on_end_changed(self, index: int):
         year = self.years[index]
@@ -80,7 +89,6 @@ class ElectricVehiclesMapTab(QWidget):
             return
         self.end_year = year
         self.label_end.setText(f"Do roku: {self.end_year}")
-        self.render_map()
 
     def load_ev_data(self, data_path: str) -> pd.DataFrame:
         df_raw = pd.read_excel(data_path, sheet_name="Sheet 3", skiprows=9, engine="openpyxl")
@@ -128,19 +136,15 @@ class ElectricVehiclesMapTab(QWidget):
             .rename(columns={"value": "cumulative_ev"})
         )
 
-        merged = self.map_data.merge(cum_ev, on="geo", how="left")
-        merged = merged[merged["cumulative_ev"].notna()]
-
-        if merged.empty or merged.geometry.isnull().all():
+        if cum_ev.empty:
             return
 
-        geojson = json.loads(merged.to_json())
         fig = go.Figure(go.Choropleth(
-            geojson=geojson,
-            locations=merged["geo"],
-            z=merged["cumulative_ev"],
+            geojson=self.map_geojson,
+            locations=cum_ev["geo"],
+            z=cum_ev["cumulative_ev"],
             featureidkey="properties.geo",
-            text=merged["geo"],
+            text=cum_ev["geo"],
             colorscale="Viridis",
             marker_line_width=0.5,
             colorbar=dict(
@@ -166,6 +170,6 @@ class ElectricVehiclesMapTab(QWidget):
             width=1200
         )
 
-        html_file = tempfile.NamedTemporaryFile(delete=False, suffix=".html")
-        pio.write_html(fig, file=html_file.name, full_html=True, include_plotlyjs="cdn")
-        self.web_view.load(QUrl.fromLocalFile(html_file.name))
+        html = pio.to_html(fig, full_html=False, include_plotlyjs="cdn")
+        self.web_view.setHtml(html, QUrl(""))
+


### PR DESCRIPTION
## Summary
- reduce repeated geojson conversions for map tabs
- avoid filesystem I/O by rendering Plotly figures directly into the web view
- update maps/plots only after releasing sliders to avoid excessive redraws

## Testing
- `python -m py_compile gui/map_view/electric_vehicles_map_tab.py gui/map_view/electric_vehicles_countries_tab.py gui/chart_view/chart_view.py`

------
https://chatgpt.com/codex/tasks/task_e_6844145d47c8833394f71ace41bd5e79