### PR TITLE
Fix year ranges in map sliders

### DIFF
--- a/data/repository.py
+++ b/data/repository.py
@@ -3,15 +3,23 @@ import pandas as pd
 class ExcelVehicleDataRepository:
     def __init__(self, ev_path: str, env_path: str):
         # 1. EV data (tran_r_elvehst...)
-        self.ev_data = pd.read_excel(ev_path, sheet_name="Sheet 3", skiprows=9, engine="openpyxl")
+        # Wczytujemy dane EV. W arkuszu po ośmiu wierszach znajdują się nazwy
+        # kolumn z latami (2018, 2019, ...). Kolejny wiersz powtarza nagłówki
+        # "GEO (Codes)", dlatego pomijamy go przy wczytywaniu.
+        self.ev_data = pd.read_excel(
+            ev_path,
+            sheet_name="Sheet 3",
+            skiprows=8,
+            engine="openpyxl",
+        ).iloc[1:]
 
         self.records = []
         year_columns_ev = {
-            "Unnamed: 1": 2018,
-            "Unnamed: 2": 2019,
-            "Unnamed: 3": 2020,
-            "Unnamed: 4": 2021,
-            "Unnamed: 5": 2022
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         for _, row in self.ev_data.iterrows():
@@ -34,20 +42,30 @@ class ExcelVehicleDataRepository:
         self.df = pd.DataFrame(self.records)
 
         # 2. ENV data (env_waselvt...)
-        self.env_data = pd.read_excel(env_path, sheet_name="Sheet 1", skiprows=9, engine="openpyxl")
+        # Dane ENV mają podobną strukturę – po ośmiu wierszach znajdują się
+        # kolumny z latami, a pierwszy wiersz po nagłówku należy pominąć.
+        self.env_data = (
+            pd.read_excel(
+                env_path,
+                sheet_name="Sheet 1",
+                skiprows=8,
+                engine="openpyxl",
+            )
+            .iloc[1:]
+        )
 
         self.env_records = []
         year_columns_env = {
-            "Unnamed: 1": 2013,
-            "Unnamed: 2": 2014,
-            "Unnamed: 3": 2015,
-            "Unnamed: 4": 2016,
-            "Unnamed: 5": 2017,
-            "Unnamed: 6": 2018,
-            "Unnamed: 7": 2019,
-            "Unnamed: 8": 2020,
-            "Unnamed: 9": 2021,
-            "Unnamed: 10": 2022
+            "2013": 2013,
+            "2014": 2014,
+            "2015": 2015,
+            "2016": 2016,
+            "2017": 2017,
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         for _, row in self.env_data.iterrows():

--- a/gui/map_view/electric_vehicles_countries_tab.py
+++ b/gui/map_view/electric_vehicles_countries_tab.py
@@ -118,35 +118,38 @@ class ElectricVehiclesCountriesTab(QWidget):
 
     def load_env_data(self, data_path: str) -> pd.DataFrame:
         """
-        Wczytuje plik Excel z danymi EV:
-        - skiprows=9 (header: "GEO (Codes)", "GEO (Labels)", "Unnamed: 2"..."Unnamed: 10")
-        - "GEO (Codes)" – kod kraju (np. "PL", "DE"), "GEO (Labels)" – nazwa kraju
-        - "Unnamed: 2" → 2018, "Unnamed: 4" → 2019, ..., "Unnamed: 10" → 2022
-        Zwraca DataFrame ["geo","name","year","value"].
+        Wczytuje plik Excel z danymi ENV.
+        Pierwszych osiem wierszy zawiera opis, kolejne wiersze zaczynają się od
+        kolumny "TIME" z nazwą kraju oraz kolumn z latami (2013–2022). Pierwszy
+        wiersz po nagłówku powtarza opisy i jest pomijany.
+        Zwraca DataFrame z kolumnami: ``geo``, ``name``, ``year`` i ``value``.
         """
-        df_raw = pd.read_excel(
-            data_path,
-            sheet_name="Sheet 1",
-            skiprows=9,
-            engine="openpyxl"
+        df_raw = (
+            pd.read_excel(
+                data_path,
+                sheet_name="Sheet 1",
+                skiprows=8,
+                engine="openpyxl",
+            )
+            .iloc[1:]
         )
 
         year_columns = {
-            "Unnamed: 1": 2013,
-            "Unnamed: 2": 2014,
-            "Unnamed: 3": 2015,
-            "Unnamed: 4": 2016,
-            "Unnamed: 5": 2017,
-            "Unnamed: 6": 2018,
-            "Unnamed: 7": 2019,
-            "Unnamed: 8": 2020,
-            "Unnamed: 9": 2021,
-            "Unnamed: 10": 2022
+            "2013": 2013,
+            "2014": 2014,
+            "2015": 2015,
+            "2016": 2016,
+            "2017": 2017,
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         records = []
         for _, row in df_raw.iterrows():
-            name = str(row.get("GEO (Labels)", "")).strip()
+            name = str(row.get("TIME", "")).strip()
             geo = self.country_name_to_code.get(name)
             if not geo:
                 continue

--- a/gui/map_view/electric_vehicles_map_tab.py
+++ b/gui/map_view/electric_vehicles_map_tab.py
@@ -84,20 +84,31 @@ class ElectricVehiclesMapTab(QWidget):
         self.render_map()
 
     def load_ev_data(self, data_path: str) -> pd.DataFrame:
-        df_raw = pd.read_excel(data_path, sheet_name="Sheet 3", skiprows=9, engine="openpyxl")
+        """Wczytuje arkusz z danymi EV i zwraca dane w formie DataFrame.
+
+        Plik zawiera osiem wierszy nagłówkowych opisujących zestaw danych.
+        Następny wiersz zawiera nazwy kolumn (``TIME`` z kodem regionu,
+        ``TIME.1`` z nazwą oraz kolumny lat od 2018 do 2022). Wiersz
+        bezpośrednio po nagłówku powtarza te kolumny i jest pomijany.
+        """
+
+        df_raw = (
+            pd.read_excel(data_path, sheet_name="Sheet 3", skiprows=8, engine="openpyxl")
+            .iloc[1:]
+        )
 
         year_columns = {
-            "Unnamed: 1": 2018,
-            "Unnamed: 2": 2019,
-            "Unnamed: 3": 2020,
-            "Unnamed: 4": 2021,
-            "Unnamed: 5": 2022
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         records = []
         for _, row in df_raw.iterrows():
-            geo = str(row["GEO (Codes)"]).strip()
-            name = str(row["GEO (Labels)"]).strip()
+            geo = str(row["TIME"]).strip()
+            name = str(row["TIME.1"]).strip()
             # Bierzemy tylko kraje (kod długości 2, np. "PL", "DE" itd.)
             for col_name, rok in year_columns.items():
                 val = row.get(col_name)


### PR DESCRIPTION
## Summary
- parse all year columns while reading EV and ENV Excel files
- update map tabs to load the revised columns
- refresh docstrings describing the new formats

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68441d2cca848333981256b7a8878fe4