### PR TITLE
Fix year ranges in map sliders

### DIFF
--- a/data/repository.py
+++ b/data/repository.py
@@ -3,15 +3,28 @@ import pandas as pd
 class ExcelVehicleDataRepository:
     def __init__(self, ev_path: str, env_path: str):
         # 1. EV data (tran_r_elvehst...)
-        self.ev_data = pd.read_excel(ev_path, sheet_name="Sheet 3", skiprows=9, engine="openpyxl")
+        # Wczytujemy dane EV. W arkuszu po ośmiu wierszach znajdują się nazwy
+        # kolumn z latami (2018, 2019, ...). Kolejny wiersz powtarza nagłówki
+        # "GEO (Codes)", dlatego pomijamy go przy wczytywaniu.
+        self.ev_data = pd.read_excel(
+            ev_path,
+            sheet_name="Sheet 3",
+            skiprows=8,
+            engine="openpyxl",
+        )
+        self.ev_data.rename(
+            columns={"TIME": "GEO (Codes)", "TIME.1": "GEO (Labels)"},
+            inplace=True,
+        )
+        self.ev_data = self.ev_data.iloc[1:]
 
         self.records = []
         year_columns_ev = {
-            "Unnamed: 1": 2018,
-            "Unnamed: 2": 2019,
-            "Unnamed: 3": 2020,
-            "Unnamed: 4": 2021,
-            "Unnamed: 5": 2022
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         for _, row in self.ev_data.iterrows():
@@ -34,20 +47,29 @@ class ExcelVehicleDataRepository:
         self.df = pd.DataFrame(self.records)
 
         # 2. ENV data (env_waselvt...)
-        self.env_data = pd.read_excel(env_path, sheet_name="Sheet 1", skiprows=9, engine="openpyxl")
+        # Dane ENV mają podobną strukturę – po ośmiu wierszach znajdują się
+        # kolumny z latami, a pierwszy wiersz po nagłówku należy pominąć.
+        self.env_data = pd.read_excel(
+            env_path,
+            sheet_name="Sheet 1",
+            skiprows=8,
+            engine="openpyxl",
+        )
+        self.env_data.rename(columns={"TIME": "GEO (Labels)"}, inplace=True)
+        self.env_data = self.env_data.iloc[1:]
 
         self.env_records = []
         year_columns_env = {
-            "Unnamed: 1": 2013,
-            "Unnamed: 2": 2014,
-            "Unnamed: 3": 2015,
-            "Unnamed: 4": 2016,
-            "Unnamed: 5": 2017,
-            "Unnamed: 6": 2018,
-            "Unnamed: 7": 2019,
-            "Unnamed: 8": 2020,
-            "Unnamed: 9": 2021,
-            "Unnamed: 10": 2022
+            "2013": 2013,
+            "2014": 2014,
+            "2015": 2015,
+            "2016": 2016,
+            "2017": 2017,
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         for _, row in self.env_data.iterrows():

--- a/gui/map_view/electric_vehicles_countries_tab.py
+++ b/gui/map_view/electric_vehicles_countries_tab.py
@@ -118,30 +118,32 @@ class ElectricVehiclesCountriesTab(QWidget):
 
     def load_env_data(self, data_path: str) -> pd.DataFrame:
         """
-        Wczytuje plik Excel z danymi EV:
-        - skiprows=9 (header: "GEO (Codes)", "GEO (Labels)", "Unnamed: 2"..."Unnamed: 10")
-        - "GEO (Codes)" – kod kraju (np. "PL", "DE"), "GEO (Labels)" – nazwa kraju
-        - "Unnamed: 2" → 2018, "Unnamed: 4" → 2019, ..., "Unnamed: 10" → 2022
-        Zwraca DataFrame ["geo","name","year","value"].
+        Wczytuje plik Excel z danymi ENV.
+        Pierwszych osiem wierszy zawiera opis zestawu. Dziewiąty wiersz
+        zawiera nagłówki: ``GEO (Labels)`` oraz kolumny z latami 2013–2022.
+        Kolejny wiersz powtarza nagłówki i jest pomijany.
+        Zwraca DataFrame z kolumnami: ``geo``, ``name``, ``year`` i ``value``.
         """
         df_raw = pd.read_excel(
             data_path,
             sheet_name="Sheet 1",
-            skiprows=9,
-            engine="openpyxl"
+            skiprows=8,
+            engine="openpyxl",
         )
+        df_raw.rename(columns={"TIME": "GEO (Labels)"}, inplace=True)
+        df_raw = df_raw.iloc[1:]
 
         year_columns = {
-            "Unnamed: 1": 2013,
-            "Unnamed: 2": 2014,
-            "Unnamed: 3": 2015,
-            "Unnamed: 4": 2016,
-            "Unnamed: 5": 2017,
-            "Unnamed: 6": 2018,
-            "Unnamed: 7": 2019,
-            "Unnamed: 8": 2020,
-            "Unnamed: 9": 2021,
-            "Unnamed: 10": 2022
+            "2013": 2013,
+            "2014": 2014,
+            "2015": 2015,
+            "2016": 2016,
+            "2017": 2017,
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         records = []

--- a/gui/map_view/electric_vehicles_map_tab.py
+++ b/gui/map_view/electric_vehicles_map_tab.py
@@ -84,14 +84,31 @@ class ElectricVehiclesMapTab(QWidget):
         self.render_map()
 
     def load_ev_data(self, data_path: str) -> pd.DataFrame:
-        df_raw = pd.read_excel(data_path, sheet_name="Sheet 3", skiprows=9, engine="openpyxl")
+        """Wczytuje arkusz z danymi EV i zwraca dane w formie ``DataFrame``.
+
+        W pliku pierwszych osiem wierszy to opis zestawu. Dziewiąty wiersz
+        zawiera nagłówki: ``GEO (Codes)``, ``GEO (Labels)`` oraz kolumny lat
+        od 2018 do 2022. Kolejny wiersz powtarza nagłówki i jest pomijany.
+        """
+
+        df_raw = pd.read_excel(
+            data_path,
+            sheet_name="Sheet 3",
+            skiprows=8,
+            engine="openpyxl",
+        )
+        df_raw.rename(
+            columns={"TIME": "GEO (Codes)", "TIME.1": "GEO (Labels)"},
+            inplace=True,
+        )
+        df_raw = df_raw.iloc[1:]
 
         year_columns = {
-            "Unnamed: 1": 2018,
-            "Unnamed: 2": 2019,
-            "Unnamed: 3": 2020,
-            "Unnamed: 4": 2021,
-            "Unnamed: 5": 2022
+            "2018": 2018,
+            "2019": 2019,
+            "2020": 2020,
+            "2021": 2021,
+            "2022": 2022,
         }
 
         records = []


### PR DESCRIPTION
## Summary
- ensure EV and ENV Excel columns are renamed to use GEO headers
- adjust map tabs to read the renamed columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68441d2cca848333981256b7a8878fe4