### PR TITLE
Add percent sign in region map

### DIFF
--- a/gui/map_view/electric_vehicles_map_tab.py
+++ b/gui/map_view/electric_vehicles_map_tab.py
@@ -206,10 +206,11 @@ class ElectricVehiclesMapTab(QWidget):
                 title=f"Średni udział ({self.start_year}–{self.end_year})",
                 x=1.02,
                 len=0.75,
-                thickness=15
+                thickness=15,
+                ticksuffix="%"
             )
         ))
-        fig.update_traces(hovertemplate="%{text}<br>%{z}<extra></extra>")
+        fig.update_traces(hovertemplate="%{text}<br>%{z}%<extra></extra>")
 
         if self.region_mode == "PL":
             minx, miny, maxx, maxy = merged.geometry.total_bounds


### PR DESCRIPTION
## Summary
- update region map view to show percent sign after values

## Testing
- `pip install pandas openpyxl geopandas plotly`

------
https://chatgpt.com/codex/tasks/task_e_68442e90161c83339b970cd1bec50939